### PR TITLE
feat: 유저 이미지 및 마이페이지 관련 기능 개선

### DIFF
--- a/my-app/src/app/(CommonLayout)/mypage/edit/page.tsx
+++ b/my-app/src/app/(CommonLayout)/mypage/edit/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession, authClient } from '@/lib/auth-client';
-import ImageUpload from '@/components/common/ImageUpload/ImageUpload';
+import { PictureIcon } from '../../../../../public/icon';
+import { useRef } from 'react';
 
 export default function EditProfilePage() {
     const { data: session, isPending } = useSession();
@@ -18,7 +19,32 @@ export default function EditProfilePage() {
     const [confirmPassword, setConfirmPassword] = useState('');
 
     const [loading, setLoading] = useState(false);
+    const [uploading, setUploading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+
+        setUploading(true);
+        setError(null);
+        try {
+            const formData = new FormData();
+            formData.append('file', file);
+            formData.append('folder', 'profiles');
+
+            const res = await fetch('/api/upload', { method: 'POST', body: formData });
+            const data = await res.json();
+
+            if (!res.ok) throw new Error(data.error || '업로드 실패');
+            setProfileImage(data.url);
+        } catch (err: any) {
+            setError(err.message || '이미지 업로드 중 오류가 발생했습니다.');
+        } finally {
+            setUploading(false);
+        }
+    };
 
     useEffect(() => {
         if (!isPending && !session) {
@@ -116,10 +142,36 @@ export default function EditProfilePage() {
                             <div className="flex flex-col items-start gap-4">
                                 <label className="text-sm font-bold text-[#666666] ml-1">프로필 이미지</label>
                                 <div className="flex items-center gap-8 w-full p-4 rounded-2xl bg-gray-50/50">
-                                    <ImageUpload
-                                        folder="profiles"
-                                        currentUrl={profileImage}
-                                        onUpload={(url) => setProfileImage(url)}
+                                    <div
+                                        className="relative group w-24 h-24 rounded-full overflow-hidden border-2 border-dashed border-gray-200 flex items-center justify-center bg-white cursor-pointer hover:border-[#00B461] transition-all"
+                                        onClick={() => fileInputRef.current?.click()}
+                                    >
+                                        {uploading ? (
+                                            <div className="flex flex-col items-center gap-1">
+                                                <div className="w-5 h-5 border-2 border-[#00B461] border-t-transparent rounded-full animate-spin" />
+                                                <span className="text-[10px] text-[#00B461] font-bold">UP</span>
+                                            </div>
+                                        ) : (
+                                            <>
+                                                {profileImage ? (
+                                                    <img src={profileImage} alt="Preview" className="w-full h-full object-cover" />
+                                                ) : (
+                                                    <div className="bg-gray-100 w-full h-full flex items-center justify-center">
+                                                        <PictureIcon />
+                                                    </div>
+                                                )}
+                                                <div className="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                                                    <PictureIcon />
+                                                </div>
+                                            </>
+                                        )}
+                                    </div>
+                                    <input
+                                        type="file"
+                                        ref={fileInputRef}
+                                        className="hidden"
+                                        accept="image/*"
+                                        onChange={handleFileChange}
                                     />
                                     <div className="text-xs text-[#999999] leading-relaxed">
                                         <p>• 1:1 비율의 이미지를 권장합니다.</p>

--- a/my-app/src/app/api/user/my-posts/route.ts
+++ b/my-app/src/app/api/user/my-posts/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/db';
+import { post, postLikes, comment } from '@/db/schema/post';
+import { eq, desc, and, count, inArray } from 'drizzle-orm';
+import { auth } from '@/lib/auth';
+import { headers } from 'next/headers';
+import type { ApiEnvelope, ApiPaginationEnvelope } from '@/types/api-envelopes';
+
+export async function GET(req: NextRequest) {
+    try {
+        const session = await auth.api.getSession({ headers: await headers() });
+
+        if (!session) {
+            return NextResponse.json(
+                { success: false, error: { message: '로그인이 필요합니다.' } } satisfies ApiEnvelope<never>,
+                { status: 401 },
+            );
+        }
+
+        const userId = session.user.id;
+        const { searchParams } = new URL(req.url);
+        const page = Math.max(1, Number(searchParams.get('page') ?? '1'));
+        const pageSize = Math.min(50, Math.max(1, Number(searchParams.get('pageSize') ?? '10')));
+        const offset = (page - 1) * pageSize;
+
+        const where = and(eq(post.status, 'ACTIVE'), eq(post.userId, userId));
+
+        const [posts, [{ total }]] = await Promise.all([
+            db
+                .select({
+                    postId: post.postId,
+                    title: post.title,
+                    content: post.content,
+                    category: post.category,
+                    image1: post.image1,
+                    image2: post.image2,
+                    image3: post.image3,
+                    createdAt: post.createdAt,
+                    userId: post.userId,
+                })
+                .from(post)
+                .where(where)
+                .orderBy(desc(post.createdAt))
+                .limit(pageSize)
+                .offset(offset),
+            db.select({ total: count() }).from(post).where(where),
+        ]);
+
+        if (posts.length === 0) {
+            return NextResponse.json({
+                success: true,
+                data: {
+                    items: [],
+                    pagination: { page, pageSize, total: 0, totalPages: 0 },
+                },
+            } satisfies ApiPaginationEnvelope<never>);
+        }
+
+        const postIds = posts.map((p) => p.postId);
+
+        const [likeCounts, commentCounts] = await Promise.all([
+            db
+                .select({ postId: postLikes.postId, cnt: count() })
+                .from(postLikes)
+                .where(and(inArray(postLikes.postId, postIds), eq(postLikes.status, 'ACTIVE')))
+                .groupBy(postLikes.postId),
+            db
+                .select({ postId: comment.postId, cnt: count() })
+                .from(comment)
+                .where(and(inArray(comment.postId, postIds), eq(comment.status, 'ACTIVE')))
+                .groupBy(comment.postId),
+        ]);
+
+        const likeMap = Object.fromEntries(likeCounts.map((l) => [l.postId, l.cnt]));
+        const commentMap = Object.fromEntries(commentCounts.map((c) => [c.postId, c.cnt]));
+
+        const items = posts.map((p) => ({
+            ...p,
+            likeCount: likeMap[p.postId] ?? 0,
+            commentCount: commentMap[p.postId] ?? 0,
+        }));
+
+        return NextResponse.json({
+            success: true,
+            data: {
+                items,
+                pagination: {
+                    page,
+                    pageSize,
+                    total,
+                    totalPages: Math.ceil(total / pageSize),
+                },
+            },
+        } satisfies ApiPaginationEnvelope<(typeof items)[number]>);
+    } catch (err) {
+        console.error('[GET /api/user/my-posts]', err);
+        return NextResponse.json(
+            { success: false, error: { message: '내 게시글 목록 조회 실패' } } satisfies ApiEnvelope<never>,
+            { status: 500 },
+        );
+    }
+}

--- a/my-app/src/app/page.tsx
+++ b/my-app/src/app/page.tsx
@@ -7,12 +7,10 @@ export default function Page() {
   const router = useRouter();
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      router.push('/login');
-    }, 3000); // 3초 후에 로그인 페이지로 이동
-
-    return () => clearTimeout(timer);
+    // 컴포넌트가 마운트되자마자 바로 /home으로 이동
+    router.replace('/home');
   }, [router]);
+
 
   return (
     <main className="relative flex h-full w-full flex-col items-center pt-72">

--- a/my-app/src/components/auth/SignUpForm.tsx
+++ b/my-app/src/components/auth/SignUpForm.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { signUp } from '@/lib/auth-client';
-import ImageUpload from '@/components/common/ImageUpload/ImageUpload';
+import { PictureIcon } from '../../../public/icon';
 
 const DEFAULT_IMAGE = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
 
@@ -14,6 +14,32 @@ export default function SignUpForm() {
     const [nickname, setNickname] = useState('');
     const [profileImageUrl, setProfileImageUrl] = useState(DEFAULT_IMAGE);
     const [loading, setLoading] = useState(false);
+    const [uploading, setUploading] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+
+        setUploading(true);
+        try {
+            const formData = new FormData();
+            formData.append('file', file);
+            formData.append('folder', 'profiles');
+
+            const res = await fetch('/api/upload', { method: 'POST', body: formData });
+            const data = await res.json();
+
+            if (!res.ok) throw new Error(data.error || '업로드 실패');
+            setProfileImageUrl(data.url);
+        } catch (err) {
+            console.error(err);
+            alert('이미지 업로드 중 오류가 발생했습니다.');
+        } finally {
+            setUploading(false);
+            if (e.target) e.target.value = '';
+        }
+    };
 
     const handleSignup = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -25,7 +51,7 @@ export default function SignUpForm() {
                 password,
                 name: nickname,
                 nickname,
-                userProfileImageUrl: profileImageUrl,
+                image: profileImageUrl,
             }, {
                 onSuccess: () => {
                     alert('회원가입 성공!');
@@ -44,12 +70,36 @@ export default function SignUpForm() {
 
     return (
         <form onSubmit={handleSignup} className="flex flex-col gap-6 text-black">
-            <div className="flex flex-col items-center gap-2">
-                <span className="text-sm font-medium text-gray-600">프로필 사진</span>
-                <ImageUpload
-                    folder="profiles"
-                    onUpload={setProfileImageUrl}
-                    currentUrl={profileImageUrl}
+            <div className="flex flex-col items-center gap-3">
+                <span className="text-sm font-semibold text-gray-700">프로필 사진</span>
+                <div
+                    className="relative group w-24 h-24 rounded-full overflow-hidden border-2 border-dashed border-gray-200 flex items-center justify-center bg-gray-50 cursor-pointer hover:border-green-400 transition-all shadow-sm"
+                    onClick={() => fileInputRef.current?.click()}
+                >
+                    {uploading ? (
+                        <div className="flex flex-col items-center gap-1">
+                            <div className="w-5 h-5 border-2 border-green-500 border-t-transparent rounded-full animate-spin" />
+                            <span className="text-[10px] text-green-600 font-bold">UP</span>
+                        </div>
+                    ) : (
+                        <>
+                            <img
+                                src={profileImageUrl}
+                                alt="Preview"
+                                className="w-full h-full object-cover"
+                            />
+                            <div className="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                                <PictureIcon />
+                            </div>
+                        </>
+                    )}
+                </div>
+                <input
+                    type="file"
+                    ref={fileInputRef}
+                    className="hidden"
+                    accept="image/*"
+                    onChange={handleFileChange}
                 />
             </div>
 
@@ -89,7 +139,7 @@ export default function SignUpForm() {
             </div>
 
             <button
-                disabled={loading}
+                disabled={loading || uploading}
                 className="mt-2 rounded-xl bg-green-500 py-3 font-bold text-white hover:bg-green-600 disabled:bg-gray-300"
             >
                 {loading ? '가입 중...' : '회원가입 하기'}

--- a/my-app/src/components/common/NavBar/NavBar.tsx
+++ b/my-app/src/components/common/NavBar/NavBar.tsx
@@ -49,9 +49,16 @@ export default function NavBar() {
           // 1. 로그인 상태인 경우: 로그아웃 버튼 + 프로필 이미지
           <>
             <LogoutButton />
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-green-500 text-sm font-bold text-white">
-              {initial}
-            </div>
+            <button
+              onClick={() => router.push('/mypage')}
+              className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-gray-100 bg-gray-50 transition-all hover:ring-2 hover:ring-green-400 active:scale-95"
+            >
+              <img
+                src={session.user.image || 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png'}
+                alt="My Page"
+                className="h-full w-full object-cover"
+              />
+            </button>
           </>
         ) : (
           // 2. 로그인하지 않은 경우: 로그인 버튼 표시

--- a/my-app/src/components/user/MyPostList.tsx
+++ b/my-app/src/components/user/MyPostList.tsx
@@ -1,23 +1,28 @@
-'use client';
-
 import { useSession } from '@/lib/auth-client';
 import { useEffect, useState } from 'react';
-
-interface Post {
-    id: string;
-    title: string;
-    createdAt: string;
-}
+import { useRouter } from 'next/navigation';
+import type { PostSummary } from '@/lib/post';
+import type { ApiPaginationEnvelope } from '@/types/api-envelopes';
 
 export default function MyPostList() {
     const { data: session } = useSession();
-    const [posts, setPosts] = useState<Post[]>([]);
+    const router = useRouter();
+    const [posts, setPosts] = useState<PostSummary[]>([]);
+    const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        const dummyPosts: Post[] = [
-            { id: '1', title: 'Better Auth와 Next.js 14 보안 전략', createdAt: '2026.03.03' },
-        ];
-        setPosts(dummyPosts);
+        if (!session?.user?.id) return;
+
+        setLoading(true);
+        fetch('/api/user/my-posts')
+            .then((res) => res.json())
+            .then((json: ApiPaginationEnvelope<PostSummary>) => {
+                if (json.success) {
+                    setPosts(json.data.items);
+                }
+            })
+            .catch(console.error)
+            .finally(() => setLoading(false));
     }, [session]);
 
     return (
@@ -27,17 +32,27 @@ export default function MyPostList() {
             </div>
 
             <div className="space-y-4">
-                {posts.map((post) => (
-                    <div
-                        key={post.id}
-                        className="w-full bg-white border border-[#F0F0F0] rounded-[16px] p-6 flex justify-between items-center hover:shadow-sm transition-all cursor-pointer"
-                    >
-                        <span className="text-[#444444] font-semibold text-[17px]">{post.title}</span>
-                        <span className="text-[#CCCCCC] text-sm font-medium">{post.createdAt}</span>
+                {loading ? (
+                    <div className="text-center py-20 text-gray-400">불러오는 중...</div>
+                ) : posts.length > 0 ? (
+                    posts.map((post) => (
+                        <div
+                            key={post.postId}
+                            onClick={() => router.push(`/home/${post.postId}`)}
+                            className="w-full bg-white border border-[#F0F0F0] rounded-[16px] p-6 flex justify-between items-center hover:shadow-sm transition-all cursor-pointer"
+                        >
+                            <span className="text-[#444444] font-semibold text-[17px]">{post.title}</span>
+                            <span className="text-[#CCCCCC] text-sm font-medium">
+                                {new Date(post.createdAt).toLocaleDateString('ko-KR')}
+                            </span>
+                        </div>
+                    ))
+                ) : (
+                    <div className="flex flex-col items-center justify-center py-20 text-[#CCCCCC]">
+                        <span className="text-4xl mb-4">🌱</span>
+                        <p>아직 작성한 포스트가 없습니다.</p>
+                        <p className="text-sm">첫 번째 지식의 씨앗을 심어보세요!</p>
                     </div>
-                ))}
-                {posts.length === 0 && (
-                    <div className="text-center py-20 text-[#CCCCCC]">아직 작성한 포스트가 없습니다.</div>
                 )}
             </div>
         </div>

--- a/my-app/src/lib/auth.ts
+++ b/my-app/src/lib/auth.ts
@@ -46,6 +46,37 @@ export const auth = betterAuth({
 
   plugins: [jwt()],
 
+  databaseHooks: {
+    user: {
+      create: {
+        before: async (user) => {
+          const defaultImage = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
+          if (!user.image) {
+            user.image = defaultImage;
+          }
+          // 하위 호환성을 위해 기존 필드도 동일하게 설정
+          user.userProfileImageUrl = user.image;
+
+          // 닉네임이 없을 경우 이름으로 초기화
+          if (!user.nickname) {
+            user.nickname = user.name;
+          }
+
+          return { data: user };
+        }
+      },
+      update: {
+        before: async (user) => {
+          // image가 수정될 경우 userProfileImageUrl도 함께 동기화
+          if (user.image) {
+            user.userProfileImageUrl = user.image;
+          }
+          return { data: user };
+        }
+      }
+    }
+  },
+
   session: { expiresIn: 60 * 60 * 24 * 7, updateAge: 60 * 60 * 24 },
   trustedOrigins: [process.env.BETTER_AUTH_URL ?? 'http://localhost:3000'],
 });


### PR DESCRIPTION
## #️⃣ Issue Number
close #30 

## 📝 변경사항
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
사용자 프로필 이미지 관리 시스템을 개선하고, 회원가입 및 수정 시 미리보기 기능을 추가했습니다.
기본 이미지 필드를 BetterAuth 표준인 image로 통합하되, 기존 기능과의 호환성을 위해 필드 삭제 대신 자동 동기화 로직을 구축했습니다.

### 🎯 핵심 변경 사항 (Key Changes)
- [x] SignUpForm 및 EditProfilePage 내에 직접 이미지 업로드 및 미리보기 UI(원형 아바타)를 구현했습니다.
- [x] src/lib/auth.ts에 user.create.before 및 user.update.before 훅을 추가하여 다음을 처리합니다.
a. 이미지 누락 시 기본 이미지 자동 할당
b. 닉네임 누락 시 이름(name)으로 자동 초기화
c .image 필드 변경 시 기존 userProfileImageUrl 필드와 실시간 동기화 (하위 호환 유지)
- [x] navBar 우측 아이콘(아바타) 영역을 프로필 이미지 버튼으로 교체하고 마이페이지(/mypage) 이동 링크를 연결했습니다.

### 🔍 주안점 & 리뷰 포인트
<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->
<!-- 
  - 예: 멀티 모듈 구조에서 의존성 주입 방식이 적절한지 봐주세요.
  - 예: Next.js App Router의 `params` 언래핑(unwrap) 처리가 올바른지 확인 부탁드립니다.
-->

### 🛠️ useSession 컴포넌트 훅 사용 방법
```
import { useSession } from '@/lib/auth-client';
export default function MyComponent() {
  const { data: session } = useSession();
  
  return (
    <div>
      <img src={session?.user.image} alt={session?.user.nickname} />
      <span>{session?.user.nickname}</span>
    </div>
  );
}
```
useSession을 통해 통일된 프로필 정보를 일관되게 가져올 수 있습니다.

---

## 🛠️ PR 유형
- [ ] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)
### **영향을 받는 모듈/컴포넌트:** 
src/lib/auth.ts, src/components/auth/SignUpForm.tsx, src/app/(CommonLayout)/mypage/edit/page.tsx, src/components/common/NavBar/NavBar.tsx

- /signup 페이지에서 이미지 업로드 및 미리보기 작동 수동 테스트
- /mypage/edit에서 프로필 사진 및 닉네임 변경 시 NavBar 반영 확인
- DB 툴을 이용해 user 테이블의 image와 userProfileImageUrl이 동일하게 실시간 동기화되는지 확인

### **테스트 방법:**
- [ ] 단위 테스트 (JUnit/Jest)
- [ ] 통합 테스트
- [x] 수동 API 테스트 (Postman/Swagger)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [x] 관련 이슈를 연결했습니다.
