### PR TITLE
chore:47-카테고리 로직 수정

### DIFF
--- a/my-app/src/app/(CommonLayout)/home/page.tsx
+++ b/my-app/src/app/(CommonLayout)/home/page.tsx
@@ -15,37 +15,47 @@ function HomePageContent() {
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
+  const isLoadingRef = useRef(false);
+  const hasMoreRef = useRef(true);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
-  // 카테고리 바뀌면 초기화
-  useEffect(() => {
-    setPosts([]);
-    setPage(1);
-    setHasMore(true);
-  }, [category]);
-
   const loadPosts = useCallback(
     async (currentPage: number) => {
-      if (isLoading || !hasMore) return;
+      if (isLoadingRef.current || !hasMoreRef.current) return;
+      isLoadingRef.current = true;
       setIsLoading(true);
       try {
         const data = await fetchPosts({ category, page: currentPage, pageSize: 10 });
         setPosts((prev) => (currentPage === 1 ? data.items : [...prev, ...data.items]));
-        setHasMore(data.items.length === 10); // 여기 수정
+        hasMoreRef.current = data.items.length === 10;
+        setHasMore(data.items.length === 10);
       } catch (err) {
         console.error(err);
       } finally {
+        isLoadingRef.current = false;
         setIsLoading(false);
       }
     },
-    [category, isLoading, hasMore],
+    [category],
   );
 
+  // 카테고리 바뀌면 초기화 후 1페이지 즉시 로드
   useEffect(() => {
+    setPosts([]);
+    setPage(1);
+    hasMoreRef.current = true;
+    isLoadingRef.current = false;
+    setHasMore(true);
+    setIsLoading(false);
+    loadPosts(1);
+  }, [category, loadPosts]);
+
+  // 무한스크롤: page가 1 초과일 때만 추가 로드
+  useEffect(() => {
+    if (page === 1) return;
     loadPosts(page);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, category]);
+  }, [page, loadPosts]);
 
   // IntersectionObserver 설정
   useEffect(() => {


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호, #이슈번호 -->

- Closes #47 

## 📝 변경사항
카테고리 변경 시 게시글이 표시되지 않는 버그를 수정했습니다.

기존 코드는 카테고리가 바뀔 때 두 개의 `useEffect`가 동시에 실행되면서 경쟁 조건(Race Condition)이 발생했습니다. `loadPosts`의 `useCallback`이 `isLoading` state를 클로저로 캡처하고 있어, 이전 페이지 요청으로 인해 `isLoading=true`가 된 상태에서 1페이지 재요청이 early return으로 무시되는 문제였습니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] `isLoading` / `hasMore`를 ref로도 관리하여 `loadPosts` 클로저의 stale closure 문제 해결
- [x] 카테고리 변경 effect에서 ref 초기화 후 `loadPosts(1)` 직접 호출로 경쟁 조건 제거
- [x] 무한스크롤 effect에 `page === 1` 가드 추가로 중복 호출 방지

### 🔍 주안점 & 리뷰 포인트

- `isLoadingRef` / `hasMoreRef`와 `isLoading` / `hasMore` state가 이중으로 관리됩니다. ref는 `loadPosts` 내부 가드용, state는 UI 렌더링(로딩 텍스트, IntersectionObserver 조건)용으로 역할을 분리했습니다.
- 카테고리 effect의 의존성 배열이 `[category, loadPosts]`인데, `loadPosts`는 `category`가 바뀔 때만 재생성되므로 실질적으로 `[category]`와 동일하게 동작합니다.

---

## 🛠️ PR 유형
- [ ] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)

### **영향을 받는 모듈/컴포넌트:**
`src/app/(CommonLayout)/home/page.tsx`

### **테스트 방법:**
- [x] 수동 테스트
  - 카테고리 변경 시 해당 카테고리 게시글이 정상 표시되는지 확인
  - 무한스크롤 후 카테고리 변경 시 1페이지부터 다시 로드되는지 확인
  - 카테고리를 빠르게 연속으로 변경해도 올바른 데이터가 표시되는지 확인

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [x] 관련 이슈를 연결했습니다.
