### PR TITLE
feature: UI 수정 및 게시글 프로필 이미지 영역 추가

### DIFF
--- a/my-app/src/app/(CommonLayout)/home/[postId]/page.tsx
+++ b/my-app/src/app/(CommonLayout)/home/[postId]/page.tsx
@@ -50,58 +50,75 @@ export default function PostDetailPage() {
     }
   };
 
-  if (!post) return <div className="p-32pxr text-gray-400">불러오는 중...</div>;
+  if (!post) return (
+    <div className="flex items-center justify-center gap-2 py-20 text-sm text-gray-400">
+      <div className="h-4 w-4 animate-spin rounded-full border-2 border-green-400 border-t-transparent" />
+      <span>불러오는 중...</span>
+    </div>
+  );
 
   return (
     <main className="flex flex-col gap-24pxr py-32pxr">
-      <button onClick={() => router.back()} className="self-start text-sm text-gray-400 hover:text-gray-600">
+      <button
+        onClick={() => router.back()}
+        className="self-start flex items-center gap-1 rounded-full border border-gray-200 bg-white px-12pxr py-6pxr text-sm text-gray-500 shadow-sm transition-all duration-150 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700 active:scale-95"
+      >
         ← 목록으로
       </button>
-      <article className="flex w-full flex-col gap-20pxr rounded-lg border border-[#E9ECEF] bg-white p-32pxr">
+      <article className="flex w-full flex-col gap-20pxr rounded-2xl border border-gray-100 bg-white p-32pxr shadow-sm">
         <div className="flex items-center justify-between">
-          <p className="fonts-postSubtitle">{post.category}</p>
+          <span className="inline-flex items-center rounded-full bg-green-50 px-10pxr py-4pxr text-xs font-bold text-green-600">
+            {post.category}
+          </span>
           <div className="flex gap-8pxr">
             <button
               onClick={() => router.push(`/home/${postId}/edit`)}
-              className="rounded border border-gray-200 px-12pxr py-6pxr text-sm text-gray-600 hover:bg-gray-50">
+              className="rounded-lg border border-gray-200 px-12pxr py-6pxr text-xs font-medium text-gray-600 transition-all duration-150 hover:border-gray-300 hover:bg-gray-50">
               수정
             </button>
             <button
               onClick={handleDelete}
               disabled={isDeleting}
-              className="rounded border border-red-200 px-12pxr py-6pxr text-sm text-red-500 hover:bg-red-50 disabled:opacity-50">
+              className="rounded-lg border border-red-100 px-12pxr py-6pxr text-xs font-medium text-red-400 transition-all duration-150 hover:border-red-200 hover:bg-red-50 disabled:opacity-50">
               {isDeleting ? '삭제 중...' : '삭제'}
             </button>
           </div>
         </div>
 
-        <h1 className="fonts-postTitle">{post.title}</h1>
+        <h1 className="fonts-postTitle text-2xl">{post.title}</h1>
 
-        <div className="flex items-center gap-8pxr text-sm text-gray-400">
-          <span>{post.authorNickname ?? post.authorName}</span>
+        <div className="flex items-center gap-8pxr text-xs text-gray-400">
+          {post.authorProfileImage ? (
+            <img src={post.authorProfileImage} alt={post.authorNickname ?? post.authorName} className="h-6 w-6 rounded-full object-cover" />
+          ) : (
+            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-green-100 text-xs font-bold text-green-700">
+              {(post.authorNickname ?? post.authorName ?? '?').charAt(0)}
+            </div>
+          )}
+          <span className="font-medium text-gray-600">{post.authorNickname ?? post.authorName}</span>
           <span>·</span>
           <span>{new Date(post.createdAt).toLocaleDateString('ko-KR')}</span>
         </div>
 
         {(post.image1 || post.image2 || post.image3) && (
-          <div className="flex gap-8pxr">
-            {post.image1 && <img src={post.image1} alt="이미지1" className="h-48 w-48 rounded object-cover" />}
-            {post.image2 && <img src={post.image2} alt="이미지2" className="h-48 w-48 rounded object-cover" />}
-            {post.image3 && <img src={post.image3} alt="이미지3" className="h-48 w-48 rounded object-cover" />}
+          <div className="flex gap-12pxr">
+            {post.image1 && <img src={post.image1} alt="이미지1" className="h-48 w-48 rounded-xl object-cover shadow-sm" />}
+            {post.image2 && <img src={post.image2} alt="이미지2" className="h-48 w-48 rounded-xl object-cover shadow-sm" />}
+            {post.image3 && <img src={post.image3} alt="이미지3" className="h-48 w-48 rounded-xl object-cover shadow-sm" />}
           </div>
         )}
 
         <div className="fonts-postContent" dangerouslySetInnerHTML={{ __html: post.content }}></div>
 
         {/* 좋아요/댓글 */}
-        <section className="flex gap-12pxr border-t border-gray-100 pt-16pxr">
-          <div className="flex items-center gap-4pxr">
+        <section className="flex gap-14pxr border-t border-gray-100 pt-16pxr">
+          <div className="flex items-center gap-5pxr text-gray-400">
             <CommentIcon />
-            <p className="fonts-subTitle">댓글 {post.commentCount}</p>
+            <p className="text-xs font-medium">댓글 {post.commentCount}</p>
           </div>
-          <button onClick={handleLike} className="flex items-center gap-4pxr">
+          <button onClick={handleLike} className="flex items-center gap-5pxr text-gray-400 transition-colors duration-150 hover:text-red-400">
             {liked ? <LikeFilledIcon /> : <LikeStrokeIcon />}
-            <p className="fonts-subTitle">좋아요 {likeCount}</p>
+            <p className="text-xs font-medium">좋아요 {likeCount}</p>
           </button>
         </section>
       </article>

--- a/my-app/src/app/(CommonLayout)/home/page.tsx
+++ b/my-app/src/app/(CommonLayout)/home/page.tsx
@@ -74,8 +74,14 @@ function HomePageContent() {
 
   return (
     <main className="flex flex-col gap-32pxr py-32pxr">
-      <article className="flex w-full items-center justify-between self-stretch rounded-lg border border-dashed border-[#00C471] bg-[rgba(234,251,242,0.30)] p-20pxr">
-        🌱 오늘 배운 지식을 기록하고 공유해보세요.
+      <article className="flex w-full items-center justify-between self-stretch rounded-2xl border border-green-100 bg-gradient-to-r from-green-50 via-emerald-50 to-teal-50 p-24pxr shadow-sm">
+        <div className="flex items-center gap-12pxr">
+          <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-white shadow-sm text-lg">🌱</span>
+          <div>
+            <p className="text-sm font-bold text-green-800">오늘 배운 지식을 기록해보세요</p>
+            <p className="text-xs text-green-600/70 mt-1">꾸준한 기록이 성장을 만듭니다</p>
+          </div>
+        </div>
         <MainBtn
           className="text-white"
           onClick={() => router.push(`/home/write?category=${encodeURIComponent(category)}`)}>
@@ -93,11 +99,19 @@ function HomePageContent() {
             commentCount={post.commentCount}
             likeCount={post.likeCount}
             liked={post.liked}
+            authorName={post.authorName}
+            authorNickname={post.authorNickname}
+            authorProfileImage={post.authorProfileImage}
           />
         </div>
       ))}
 
-      {isLoading && <p className="text-center text-sm text-gray-400">불러오는 중...</p>}
+      {isLoading && (
+        <div className="flex items-center justify-center gap-2 py-8 text-sm text-gray-400">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-green-400 border-t-transparent" />
+          <span>불러오는 중...</span>
+        </div>
+      )}
 
       <div ref={bottomRef} className="h-1" />
     </main>

--- a/my-app/src/app/(CommonLayout)/login/page.tsx
+++ b/my-app/src/app/(CommonLayout)/login/page.tsx
@@ -3,32 +3,44 @@ import SocialLoginButtons from "@/components/auth/SocialLoginButtons";
 
 export default function LoginPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
-      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-xl ring-1 ring-gray-100">
-        <h1 className="mb-8 text-center text-3xl font-extrabold text-gray-900 text-black">로그인</h1>
+    <main className="flex min-h-screen items-center justify-center bg-gradient-to-br from-green-50 via-white to-emerald-50 p-4">
+      <div className="w-full max-w-md overflow-hidden rounded-3xl bg-white shadow-xl ring-1 ring-gray-100">
+        <div className="h-1.5 w-full bg-gradient-to-r from-[#00C471] to-emerald-400" />
 
-        <LogInForm />
-
-        <div className="mt-8">
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-gray-200"></div>
+        <div className="p-8">
+          <div className="mb-8 flex flex-col items-center gap-1">
+            <div className="flex items-center gap-2">
+              <span className="text-2xl font-black tracking-tight text-[#00C471]">싹심기</span>
+              <span>🌱</span>
             </div>
-            <div className="relative flex justify-center text-sm">
-              <span className="bg-white px-2 text-gray-500">또는 소셜 계정으로 로그인</span>
-            </div>
+            <p className="text-xs text-gray-400">프로디지털아카데미 학습 커뮤니티</p>
           </div>
 
-          <div className="mt-6">
-            <SocialLoginButtons />
-          </div>
+          <h1 className="mb-6 text-center text-xl font-bold text-gray-800">로그인</h1>
 
-          <p className="mt-8 text-center text-sm text-gray-500">
-            아직 계정이 없으신가요?{' '}
-            <a href="/signup" className="font-bold text-green-500 hover:underline">
-              회원가입하기
-            </a>
-          </p>
+          <LogInForm />
+
+          <div className="mt-8">
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-gray-100"></div>
+              </div>
+              <div className="relative flex justify-center text-xs">
+                <span className="bg-white px-3 text-gray-400">또는 소셜 계정으로 로그인</span>
+              </div>
+            </div>
+
+            <div className="mt-5">
+              <SocialLoginButtons />
+            </div>
+
+            <p className="mt-7 text-center text-sm text-gray-400">
+              아직 계정이 없으신가요?{' '}
+              <a href="/signup" className="font-bold text-[#00C471] hover:underline">
+                회원가입하기
+              </a>
+            </p>
+          </div>
         </div>
       </div>
     </main>

--- a/my-app/src/app/(CommonLayout)/signup/page.tsx
+++ b/my-app/src/app/(CommonLayout)/signup/page.tsx
@@ -2,18 +2,30 @@ import SignUpForm from "@/components/auth/SignUpForm";
 
 export default function SignupPage() {
     return (
-        <main className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
-            <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-xl ring-1 ring-gray-100">
-                <h1 className="mb-8 text-center text-3xl font-extrabold text-gray-900 text-black">회원가입</h1>
+        <main className="flex min-h-screen items-center justify-center bg-gradient-to-br from-green-50 via-white to-emerald-50 p-4">
+            <div className="w-full max-w-md overflow-hidden rounded-3xl bg-white shadow-xl ring-1 ring-gray-100">
+                <div className="h-1.5 w-full bg-gradient-to-r from-[#00C471] to-emerald-400" />
 
-                <SignUpForm />
+                <div className="p-8">
+                    <div className="mb-6 flex flex-col items-center gap-1">
+                        <div className="flex items-center gap-2">
+                            <span className="text-2xl font-black tracking-tight text-[#00C471]">싹심기</span>
+                            <span>🌱</span>
+                        </div>
+                        <p className="text-xs text-gray-400">프로디지털아카데미 학습 커뮤니티</p>
+                    </div>
 
-                <p className="mt-6 text-center text-sm text-gray-500">
-                    이미 계정이 있으신가요?{' '}
-                    <a href="/login" className="font-bold text-green-600 hover:underline">
-                        로그인하기
-                    </a>
-                </p>
+                    <h1 className="mb-6 text-center text-xl font-bold text-gray-800">회원가입</h1>
+
+                    <SignUpForm />
+
+                    <p className="mt-6 text-center text-sm text-gray-400">
+                        이미 계정이 있으신가요?{' '}
+                        <a href="/login" className="font-bold text-[#00C471] hover:underline">
+                            로그인하기
+                        </a>
+                    </p>
+                </div>
             </div>
         </main>
     );

--- a/my-app/src/app/api/posts/[postId]/route.ts
+++ b/my-app/src/app/api/posts/[postId]/route.ts
@@ -36,7 +36,7 @@ export async function GET(req: NextRequest, { params }: Params) {
         userId: post.userId,
         authorName: user.name,
         authorNickname: user.nickname,
-        authorProfileImage: user.userProfileImageUrl,
+        authorProfileImage: user.image,
       })
       .from(post)
       .innerJoin(user, eq(post.userId, user.id))

--- a/my-app/src/app/api/posts/route.ts
+++ b/my-app/src/app/api/posts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/db';
 import { post, postLikes, comment } from '@/db/schema/post';
+import { user } from '@/db/schema/auth';
 import { eq, desc, and, count, inArray } from 'drizzle-orm';
 import type { ApiEnvelope, ApiPaginationEnvelope } from '@/types/api-envelopes';
 import { auth } from '@/lib/auth';
@@ -34,8 +35,12 @@ export async function GET(req: NextRequest) {
           image3: post.image3,
           createdAt: post.createdAt,
           userId: post.userId,
+          authorName: user.name,
+          authorNickname: user.nickname,
+          authorProfileImage: user.image,
         })
         .from(post)
+        .innerJoin(user, eq(post.userId, user.id))
         .where(where)
         .orderBy(desc(post.createdAt))
         .limit(pageSize)

--- a/my-app/src/app/globals.css
+++ b/my-app/src/app/globals.css
@@ -16,10 +16,10 @@
     min-width: 1024px;
     height: 100dvh;
     margin: 0 auto;
-    background-color: white;
+    background-color: #F7F8FA;
     -ms-overflow-style: none;
     position: relative;
-    box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.08);
   }
 
   ::-webkit-scrollbar {

--- a/my-app/src/components/auth/LogInForm.tsx
+++ b/my-app/src/components/auth/LogInForm.tsx
@@ -42,7 +42,7 @@ export default function LogInForm() {
                 <input
                     required
                     type="email"
-                    className="rounded-lg border border-gray-200 p-3 outline-none focus:ring-2 focus:ring-blue-400"
+                    className="rounded-xl border border-gray-200 bg-gray-50/50 p-3 text-sm outline-none transition-all duration-150 focus:ring-2 focus:ring-green-400/40 focus:border-green-400"
                     placeholder="hello@example.com"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
@@ -54,7 +54,7 @@ export default function LogInForm() {
                 <input
                     required
                     type="password"
-                    className="rounded-lg border border-gray-200 p-3 outline-none focus:ring-2 focus:ring-blue-400"
+                    className="rounded-xl border border-gray-200 bg-gray-50/50 p-3 text-sm outline-none transition-all duration-150 focus:ring-2 focus:ring-green-400/40 focus:border-green-400"
                     placeholder="비밀번호를 입력하세요"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
@@ -63,7 +63,7 @@ export default function LogInForm() {
 
             <button
                 disabled={loading}
-                className="mt-2 rounded-xl bg-green-500 py-3 font-bold text-white transition-all hover:bg-green-600 active:scale-95 disabled:bg-gray-300"
+                className="mt-2 rounded-xl bg-[#00C471] py-3 font-bold text-white shadow-sm transition-all duration-150 hover:bg-green-600 active:scale-95 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
             >
                 {loading ? '로그인 중...' : '로그인'}
             </button>

--- a/my-app/src/components/auth/LogoutButton.tsx
+++ b/my-app/src/components/auth/LogoutButton.tsx
@@ -30,7 +30,7 @@ export default function LogoutButton() {
     return (
         <button
             onClick={handleLogout}
-            className="rounded-full bg-[#EEEEEE] px-5 py-2 text-[14px] font-semibold text-[#888888] transition-all hover:bg-gray-200 active:scale-95"
+            className="rounded-full border border-gray-200 bg-white px-5 py-2 text-[13px] font-semibold text-gray-500 shadow-sm transition-all duration-150 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700 active:scale-95"
         >
             로그아웃
         </button>

--- a/my-app/src/components/auth/SignUpForm.tsx
+++ b/my-app/src/components/auth/SignUpForm.tsx
@@ -107,7 +107,7 @@ export default function SignUpForm() {
                 <label className="text-sm font-semibold text-gray-700">닉네임</label>
                 <input
                     required
-                    className="rounded-lg border border-gray-200 p-3 outline-none focus:ring-2 focus:ring-green-400"
+                    className="rounded-xl border border-gray-200 bg-gray-50/50 p-3 text-sm outline-none transition-all duration-150 focus:border-green-400 focus:ring-2 focus:ring-green-400/40"
                     placeholder="닉네임"
                     value={nickname}
                     onChange={(e) => setNickname(e.target.value)}
@@ -119,7 +119,7 @@ export default function SignUpForm() {
                 <input
                     required
                     type="email"
-                    className="rounded-lg border border-gray-200 p-3 outline-none focus:ring-2 focus:ring-green-400"
+                    className="rounded-xl border border-gray-200 bg-gray-50/50 p-3 text-sm outline-none transition-all duration-150 focus:border-green-400 focus:ring-2 focus:ring-green-400/40"
                     placeholder="email@example.com"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
@@ -131,7 +131,7 @@ export default function SignUpForm() {
                 <input
                     required
                     type="password"
-                    className="rounded-lg border border-gray-200 p-3 outline-none focus:ring-2 focus:ring-green-400"
+                    className="rounded-xl border border-gray-200 bg-gray-50/50 p-3 text-sm outline-none transition-all duration-150 focus:border-green-400 focus:ring-2 focus:ring-green-400/40"
                     placeholder="8자 이상"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
@@ -140,7 +140,7 @@ export default function SignUpForm() {
 
             <button
                 disabled={loading || uploading}
-                className="mt-2 rounded-xl bg-green-500 py-3 font-bold text-white hover:bg-green-600 disabled:bg-gray-300"
+                className="mt-2 rounded-xl bg-[#00C471] py-3 font-bold text-white shadow-sm transition-all duration-150 hover:bg-green-600 active:scale-95 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
             >
                 {loading ? '가입 중...' : '회원가입 하기'}
             </button>

--- a/my-app/src/components/chat/ChatInput.tsx
+++ b/my-app/src/components/chat/ChatInput.tsx
@@ -24,20 +24,20 @@ export default function ChatInput({ onSend }: Props) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex items-center gap-2 px-4 py-3 border-t border-gray-100">
+    <form onSubmit={handleSubmit} className="flex items-center gap-2 border-t border-gray-100 bg-white px-4 py-3">
       <input
         ref={inputRef}
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
         placeholder="메시지를 입력하세요"
-        className="flex-1 text-sm bg-gray-100 rounded-full px-4 py-2 outline-none"
+        className="flex-1 rounded-full border border-gray-200 bg-gray-50 px-4 py-2 text-sm outline-none transition-all duration-150 focus:border-green-300 focus:bg-white focus:ring-2 focus:ring-green-400/20"
         disabled={sending}
       />
       <button
         type="submit"
         disabled={!value.trim() || sending}
-        className="w-8 h-8 rounded-full bg-green-500 flex items-center justify-center disabled:opacity-40"
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-[#00C471] shadow-sm transition-all duration-150 hover:bg-green-600 active:scale-95 disabled:opacity-40"
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
           <path d="M22 2L11 13" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />

--- a/my-app/src/components/chat/ChatMessage.tsx
+++ b/my-app/src/components/chat/ChatMessage.tsx
@@ -27,10 +27,10 @@ export default function ChatMessage({ message, isMe }: Props) {
 
   if (isMe) {
     return (
-      <div className="flex justify-end gap-2 px-4 py-1">
-        <div className="flex flex-col items-end gap-1 max-w-[70%]">
+      <div className="flex justify-end gap-2 px-4 py-1.5">
+        <div className="flex flex-col items-end gap-1 max-w-[72%]">
           <span className="text-[10px] text-gray-400">{time}</span>
-          <div className="bg-green-500 text-white text-sm px-3 py-2 rounded-2xl rounded-tr-sm wrap-break-words">
+          <div className="break-words rounded-2xl rounded-tr-sm bg-[#00C471] px-3.5 py-2 text-sm text-white shadow-sm">
             {message.content}
           </div>
         </div>
@@ -39,8 +39,8 @@ export default function ChatMessage({ message, isMe }: Props) {
   }
 
   return (
-    <div className="flex items-start gap-2 px-4 py-1">
-      <div className="relative w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center text-white text-xs font-bold shrink-0 overflow-hidden">
+    <div className="flex items-start gap-2 px-4 py-1.5">
+      <div className="relative flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-green-100 text-xs font-bold text-green-700 ring-1 ring-green-100">
         {message.image ? (
           <Image
             src={message.image}
@@ -52,13 +52,13 @@ export default function ChatMessage({ message, isMe }: Props) {
           initial
         )}
       </div>
-      <div className="flex flex-col gap-1 max-w-[70%]">
-        <span className="text-xs text-gray-500 font-medium">{message.nickname ?? '익명'}</span>
+      <div className="flex flex-col gap-1 max-w-[72%]">
+        <span className="text-[11px] font-semibold text-gray-500">{message.nickname ?? '익명'}</span>
         <div className="flex items-end gap-1">
-          <div className="bg-white border border-gray-200 text-gray-800 text-sm px-3 py-2 rounded-2xl rounded-tl-sm wrap-break-word">
+          <div className="break-words rounded-2xl rounded-tl-sm border border-gray-100 bg-gray-50 px-3.5 py-2 text-sm text-gray-800 shadow-sm">
             {message.content}
           </div>
-          <span className="text-[10px] text-gray-400 shrink-0">{time}</span>
+          <span className="shrink-0 text-[10px] text-gray-400">{time}</span>
         </div>
       </div>
     </div>

--- a/my-app/src/components/chat/ChatSidebar.tsx
+++ b/my-app/src/components/chat/ChatSidebar.tsx
@@ -45,9 +45,10 @@ export default function ChatSidebar() {
   };
 
   return (
-    <aside className="flex flex-col w-[320px] h-full border-l border-gray-100 bg-gray-50">
-      <div className="px-4 py-3 border-b border-gray-100 bg-white">
-        <h2 className="text-sm font-semibold text-gray-700">실시간 채팅</h2>
+    <aside className="flex flex-col w-[300px] h-full overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm">
+      <div className="flex items-center gap-2 border-b border-gray-100 bg-gradient-to-r from-green-50 to-emerald-50 px-4 py-3">
+        <div className="h-2 w-2 rounded-full bg-[#00C471] shadow-sm" />
+        <h2 className="text-sm font-bold text-gray-700">실시간 채팅</h2>
       </div>
 
       <ChatMessageList messages={messages} currentUserId={currentUserId} />

--- a/my-app/src/components/common/MainBtn.tsx
+++ b/my-app/src/components/common/MainBtn.tsx
@@ -5,7 +5,7 @@ export default function MainBtn({ children, className, onClick, disabled }: Main
     <button
       onClick={onClick}
       disabled={disabled}
-      className={`flex flex-col items-center justify-center rounded-lg bg-[#00C471] px-16pxr py-8pxr disabled:opacity-50 ${className ?? ''}`}>
+      className={`flex flex-col items-center justify-center rounded-xl bg-[#00C471] px-16pxr py-9pxr shadow-sm transition-all duration-150 hover:bg-green-600 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 ${className ?? ''}`}>
       <span className="fonts-mainBtn">{children}</span>
     </button>
   );

--- a/my-app/src/components/common/NavBar/NavBar.tsx
+++ b/my-app/src/components/common/NavBar/NavBar.tsx
@@ -12,23 +12,24 @@ export default function NavBar() {
   const { data: session } = useSession();
 
   const activeCategory = (searchParams.get('category') ?? '전체') as PostCategory;
-  const initial = session?.user?.name?.charAt(0) ?? '?';
-
   const handleCategoryClick = (category: PostCategory) => {
     if (category === '전체') router.push('/home');
     else router.push(`/home?category=${encodeURIComponent(category)}`);
   };
 
   return (
-    <nav className="flex items-center gap-18pxr border-b border-gray-100 bg-white py-35pxr">
-      <div className="flex shrink-0 items-center gap-4pxr">
-        <span className="fonts-logo tracking-tight text-green-500">싹심기</span>
-        <span>🌱</span>
-      </div>
+    <nav className="flex items-center gap-18pxr border-b border-gray-100 bg-white/95 py-20pxr shadow-sm backdrop-blur-sm">
+      <button
+        onClick={() => router.push('/home')}
+        className="flex shrink-0 items-center gap-6pxr"
+      >
+        <span className="fonts-logo tracking-tight text-[#00C471]">싹심기</span>
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-green-50 text-xs">🌱</span>
+      </button>
       <div className="flex min-w-0 flex-1 items-center justify-between">
         {/* 카테고리 영역 */}
         <section className="flex min-w-0 flex-1 items-center">
-          <div className="flex min-w-0 flex-1 items-center gap-8pxr overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <div className="flex min-w-0 flex-1 items-center gap-6pxr overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
             {POST_CATEGORIES.map((category) => (
               <NavItem
                 key={category}
@@ -43,7 +44,7 @@ export default function NavBar() {
 
         <section className="flex shrink-0 items-center"></section>
       </div>
-      {/* 우측: 출석 버튼 + 아바타 */}
+      {/* 우측: 아바타 */}
       <div className="flex min-w-[120px] items-center justify-end gap-3">
         {session ? (
           // 1. 로그인 상태인 경우: 로그아웃 버튼 + 프로필 이미지
@@ -51,7 +52,7 @@ export default function NavBar() {
             <LogoutButton />
             <button
               onClick={() => router.push('/mypage')}
-              className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-gray-100 bg-gray-50 transition-all hover:ring-2 hover:ring-green-400 active:scale-95"
+              className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border-2 border-gray-100 bg-gray-50 shadow-sm transition-all duration-200 hover:border-green-300 hover:ring-2 hover:ring-green-400/30 active:scale-95"
             >
               <img
                 src={session.user.image || 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png'}
@@ -64,7 +65,7 @@ export default function NavBar() {
           // 2. 로그인하지 않은 경우: 로그인 버튼 표시
           <button
             onClick={() => router.push('/login')}
-            className="rounded-full border border-green-500 px-4 py-2 text-sm font-medium text-green-500 transition-colors hover:bg-green-50">
+            className="rounded-full bg-[#00C471] px-5 py-2 text-sm font-semibold text-white shadow-sm transition-all duration-200 hover:bg-green-600 active:scale-95">
             로그인
           </button>
         )}

--- a/my-app/src/components/common/NavBar/NavItem.tsx
+++ b/my-app/src/components/common/NavBar/NavItem.tsx
@@ -5,10 +5,10 @@ export default function NavItem({ category, isActive, emoji, onClick }: NavItemP
     <button
       onClick={onClick}
       className={[
-        'fonts-navBar flex items-center gap-4pxr rounded-full px-16pxr py-8pxr transition-all',
+        'fonts-navBar flex items-center gap-4pxr rounded-full px-14pxr py-7pxr transition-all duration-200 whitespace-nowrap',
         isActive
-          ? 'bg-green-500 text-white'
-          : 'border border-gray-200 bg-white text-gray-600 hover:border-green-400 hover:text-green-500',
+          ? 'bg-[#00C471] text-white shadow-sm shadow-green-200'
+          : 'border border-gray-200 bg-white text-gray-500 hover:border-green-300 hover:text-[#00C471] hover:bg-green-50',
       ].join(' ')}>
       {emoji && <span className="leading-none">{emoji}</span>}
       <span>{category}</span>

--- a/my-app/src/components/home/PostCard.tsx
+++ b/my-app/src/components/home/PostCard.tsx
@@ -13,6 +13,9 @@ export default function PostCard({
   commentCount,
   likeCount: initialLikeCount,
   liked: initialLiked = false,
+  authorName,
+  authorNickname,
+  authorProfileImage,
 }: PostCardProps) {
   const [liked, setLiked] = useState(initialLiked);
   const [likeCount, setLikeCount] = useState(initialLikeCount);
@@ -29,19 +32,40 @@ export default function PostCard({
     }
   };
 
+  const displayName = authorNickname ?? authorName;
+  const initial = displayName.charAt(0);
+
   return (
-    <article className="flex w-full flex-col gap-13pxr rounded-lg border border-[#E9ECEF] bg-white p-25pxr">
-      <p className="fonts-postSubtitle">{subtitle}</p>
-      <h2 className="fonts-postTitle">{title}</h2>
-      <div className="fonts-postContent" dangerouslySetInnerHTML={{ __html: content }}></div>
-      <section className="flex gap-12pxr">
-        <div className="flex items-center gap-4pxr">
+    <article className="flex w-full flex-col gap-14pxr rounded-2xl border border-gray-100 bg-white p-28pxr shadow-sm transition-all duration-200 hover:border-gray-200 hover:shadow-md">
+      <span className="inline-flex w-fit items-center rounded-full bg-green-50 px-10pxr py-4pxr text-xs font-bold text-green-600">
+        {subtitle}
+      </span>
+      <h2 className="fonts-postTitle leading-snug">{title}</h2>
+      <div
+        className="fonts-postContent line-clamp-3 overflow-hidden text-ellipsis"
+        dangerouslySetInnerHTML={{ __html: content }}
+      ></div>
+      <div className="flex items-center gap-8pxr text-xs text-gray-400">
+        {authorProfileImage ? (
+          <img src={authorProfileImage} alt={displayName} className="h-6 w-6 rounded-full object-cover" />
+        ) : (
+          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-green-100 text-xs font-bold text-green-700">
+            {initial}
+          </div>
+        )}
+        <span className="font-medium text-gray-600">{displayName}</span>
+      </div>
+      <section className="flex gap-14pxr border-t border-gray-50 pt-14pxr">
+        <div className="flex items-center gap-5pxr text-gray-400">
           <CommentIcon />
-          <p className="fonts-subTitle">{commentCount}</p>
+          <p className="text-xs font-medium">{commentCount}</p>
         </div>
-        <button onClick={handleLike} className="flex items-center gap-4pxr">
+        <button
+          onClick={handleLike}
+          className="flex items-center gap-5pxr text-gray-400 transition-colors duration-150 hover:text-red-400"
+        >
           {liked ? <LikeFilledIcon /> : <LikeStrokeIcon />}
-          <p className="fonts-subTitle">{likeCount}</p>
+          <p className="text-xs font-medium">{likeCount}</p>
         </button>
       </section>
     </article>

--- a/my-app/src/components/user/AccountManagement.tsx
+++ b/my-app/src/components/user/AccountManagement.tsx
@@ -25,22 +25,27 @@ export default function AccountManagement() {
     };
 
     return (
-        <div className="w-full md:w-[320px] bg-[#F9F9F9] rounded-[24px] p-10 flex flex-col gap-6">
-            <h3 className="text-[19px] font-bold text-[#333333]">계정 관리</h3>
+        <div className="flex w-full flex-col gap-6 rounded-2xl border border-gray-100 bg-white p-8 shadow-sm md:w-[320px]">
+            <div className="flex items-center gap-2">
+                <div className="h-4 w-1 rounded-full bg-[#00C471]" />
+                <h3 className="text-[17px] font-bold text-[#333333]">계정 관리</h3>
+            </div>
 
-            <div className="flex flex-col gap-5 text-[15px] font-semibold text-[#888888]">
+            <div className="flex flex-col gap-1">
                 <button
                     onClick={() => router.push('/mypage/edit')}
-                    className="text-left hover:text-[#00B461] transition-colors"
+                    className="flex items-center justify-between rounded-xl px-4 py-3 text-[14px] font-semibold text-[#666666] transition-all duration-150 hover:bg-green-50 hover:text-[#00C471]"
                 >
-                    정보 수정
+                    <span>정보 수정</span>
+                    <span className="text-gray-300">›</span>
                 </button>
-                <div className="border-b border-gray-100/50"></div>
+                <div className="mx-4 border-b border-gray-100"></div>
                 <button
                     onClick={handleDeactivate}
-                    className="text-left text-[#FF7070] font-bold mt-2"
+                    className="flex items-center justify-between rounded-xl px-4 py-3 text-[14px] font-bold text-[#FF7070] transition-all duration-150 hover:bg-red-50"
                 >
-                    회원 탈퇴
+                    <span>회원 탈퇴</span>
+                    <span className="text-red-200">›</span>
                 </button>
             </div>
         </div>

--- a/my-app/src/components/user/MyPostList.tsx
+++ b/my-app/src/components/user/MyPostList.tsx
@@ -27,31 +27,38 @@ export default function MyPostList() {
 
     return (
         <div className="flex-1">
-            <div className="inline-block border-b-2 border-[#00B461] mb-10 pb-1">
+            <div className="mb-8 flex items-center gap-2">
+                <div className="h-5 w-1.5 rounded-full bg-[#00C471]" />
                 <h2 className="text-[20px] font-bold text-[#333333] tracking-tight">내가 심은 지식</h2>
             </div>
 
-            <div className="space-y-4">
+            <div className="space-y-3">
                 {loading ? (
-                    <div className="text-center py-20 text-gray-400">불러오는 중...</div>
+                    <div className="flex items-center justify-center gap-2 py-20 text-sm text-gray-400">
+                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-green-400 border-t-transparent" />
+                        <span>불러오는 중...</span>
+                    </div>
                 ) : posts.length > 0 ? (
                     posts.map((post) => (
                         <div
                             key={post.postId}
                             onClick={() => router.push(`/home/${post.postId}`)}
-                            className="w-full bg-white border border-[#F0F0F0] rounded-[16px] p-6 flex justify-between items-center hover:shadow-sm transition-all cursor-pointer"
+                            className="flex w-full cursor-pointer items-center justify-between rounded-2xl border border-gray-100 bg-white p-6 shadow-sm transition-all duration-200 hover:border-green-100 hover:shadow-md"
                         >
-                            <span className="text-[#444444] font-semibold text-[17px]">{post.title}</span>
-                            <span className="text-[#CCCCCC] text-sm font-medium">
+                            <div className="flex items-center gap-3">
+                                <div className="h-2 w-2 rounded-full bg-green-300" />
+                                <span className="text-[16px] font-semibold text-[#444444]">{post.title}</span>
+                            </div>
+                            <span className="shrink-0 text-sm font-medium text-[#CCCCCC]">
                                 {new Date(post.createdAt).toLocaleDateString('ko-KR')}
                             </span>
                         </div>
                     ))
                 ) : (
-                    <div className="flex flex-col items-center justify-center py-20 text-[#CCCCCC]">
-                        <span className="text-4xl mb-4">🌱</span>
-                        <p>아직 작성한 포스트가 없습니다.</p>
-                        <p className="text-sm">첫 번째 지식의 씨앗을 심어보세요!</p>
+                    <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-gray-200 py-20 text-[#CCCCCC]">
+                        <span className="mb-4 text-4xl">🌱</span>
+                        <p className="font-medium">아직 작성한 포스트가 없습니다.</p>
+                        <p className="mt-1 text-sm">첫 번째 지식의 씨앗을 심어보세요!</p>
                     </div>
                 )}
             </div>

--- a/my-app/src/components/user/ProfileHeader.tsx
+++ b/my-app/src/components/user/ProfileHeader.tsx
@@ -21,18 +21,18 @@ export default function ProfileHeader() {
 
     return (
         <div className="w-full">
-            {/* 상단 그린 배너 - 상단을 가득 채우는 느낌으로 */}
-            <div className="h-[200px] w-full bg-[#00B461] rounded-[40px] shadow-sm"></div>
+            {/* 상단 그린 배너 */}
+            <div className="h-[200px] w-full rounded-3xl bg-gradient-to-br from-[#00C471] via-emerald-500 to-teal-500 shadow-md shadow-green-200"></div>
 
-            {/* 프로필 콘텐츠 영역 - 평면화 */}
+            {/* 프로필 콘텐츠 영역 */}
             <div className="relative px-8 flex flex-col items-start bg-transparent">
                 {/* 프로필 아바타 */}
                 <div className="absolute -top-[70px] left-12">
-                    <div className="h-[140px] w-[140px] rounded-full border-[6px] border-white bg-white shadow-xl overflow-hidden flex items-center justify-center">
+                    <div className="h-[140px] w-[140px] overflow-hidden rounded-full border-[5px] border-white bg-white shadow-xl ring-4 ring-green-100 flex items-center justify-center">
                         {user.image ? (
                             <img src={user.image} alt={user.name} className="h-full w-full object-cover" />
                         ) : (
-                            <div className="h-full w-full bg-[#E6F7ED] flex items-center justify-center text-4xl font-black text-[#00B461]">
+                            <div className="h-full w-full bg-gradient-to-br from-green-50 to-emerald-100 flex items-center justify-center text-4xl font-black text-[#00C471]">
                                 {user.nickname || user.name ? (user.nickname || user.name).charAt(0) : '?'}
                             </div>
                         )}
@@ -41,16 +41,16 @@ export default function ProfileHeader() {
 
                 {/* 유저명, 한줄소개, 버튼 */}
                 <div className="w-full pt-[95px] flex justify-between items-start">
-                    <div className="flex flex-col gap-3">
-                        <div className="flex items-center gap-4">
-                            <span className="text-[36px] font-black text-[#333333] tracking-tighter leading-tight">
+                    <div className="flex flex-col gap-2">
+                        <div className="flex items-center gap-3">
+                            <span className="text-[32px] font-black text-[#222222] tracking-tighter leading-tight">
                                 {user.nickname || user.name}
                             </span>
-                            <div className={`flex items-center gap-1 rounded-[6px] border px-2.5 py-1 text-[13px] font-bold ${currentLevel.color}`}>
+                            <div className={`flex items-center gap-1 rounded-full border px-3 py-1 text-[12px] font-bold shadow-sm ${currentLevel.color}`}>
                                 {currentLevel.label} 🌿
                             </div>
                         </div>
-                        <p className="text-[#888888] text-[17px] font-medium leading-relaxed">
+                        <p className="text-[#999999] text-[15px] font-medium leading-relaxed">
                             학습한 내용을 꾸준히 기록하는 공간입니다.
                         </p>
                     </div>

--- a/my-app/src/features/comments/CommentForm.tsx
+++ b/my-app/src/features/comments/CommentForm.tsx
@@ -61,9 +61,9 @@ export function CommentForm({ postId, replyTarget, onSuccess, onCancel }: Props)
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2.5 rounded-2xl border border-gray-100 bg-gray-50/50 p-4 shadow-sm">
       <textarea
-        className="w-full resize-none rounded-lg border border-gray-200 p-2 text-sm focus:outline-none focus:ring-1 focus:ring-green-400"
+        className="w-full resize-none rounded-xl border border-gray-200 bg-white p-3 text-sm transition-all duration-150 focus:border-green-300 focus:outline-none focus:ring-2 focus:ring-green-400/20"
         rows={2}
         placeholder={placeholder}
         value={content}
@@ -73,14 +73,14 @@ export function CommentForm({ postId, replyTarget, onSuccess, onCancel }: Props)
       {error && <p className="text-xs text-red-500">{error}</p>}
       <div className="flex justify-end gap-2">
         {onCancel && (
-          <button type="button" onClick={onCancel} className="rounded px-3 py-1 text-xs text-gray-500 hover:bg-gray-100">
+          <button type="button" onClick={onCancel} className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors duration-150 hover:bg-gray-100">
             취소
           </button>
         )}
         <button
           type="submit"
           disabled={loading || !content.trim()}
-          className="rounded bg-[#00C471] px-3 py-1 text-xs text-white hover:bg-green-600 disabled:opacity-40"
+          className="rounded-lg bg-[#00C471] px-4 py-1.5 text-xs font-bold text-white shadow-sm transition-all duration-150 hover:bg-green-600 active:scale-95 disabled:opacity-40"
         >
           {loading ? '작성 중...' : '작성'}
         </button>

--- a/my-app/src/features/comments/CommentItem.tsx
+++ b/my-app/src/features/comments/CommentItem.tsx
@@ -29,30 +29,30 @@ export function CommentItem({ comment, postId, currentUserId, onDeleted }: Props
   }
 
   return (
-    <div className="rounded-lg border border-gray-100 bg-white p-3 shadow-sm">
+    <div className={`rounded-2xl border bg-white p-4 shadow-sm transition-all duration-150 ${isDeleted ? 'border-gray-50 bg-gray-50/50' : 'border-gray-100 hover:border-gray-200'}`}>
       <div className="flex items-start justify-between gap-2">
-        <div className="flex flex-1 gap-2">
+        <div className="flex flex-1 gap-2.5">
           {comment.author.image ? (
-            <img src={comment.author.image} alt={comment.author.nickname ?? '프로필'} className="h-7 w-7 shrink-0 rounded-full object-cover" />
+            <img src={comment.author.image} alt={comment.author.nickname ?? '프로필'} className="h-8 w-8 shrink-0 rounded-full object-cover ring-1 ring-gray-100" />
           ) : (
-            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-green-100 text-xs font-bold text-green-600">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-green-100 text-xs font-bold text-green-700">
               {(comment.author.nickname ?? '익')[0]}
             </div>
           )}
           <div className="flex-1">
-            <span className="mr-2 text-sm font-semibold text-gray-800">{comment.author.nickname ?? '익명'}</span>
-            <span className={`text-sm ${isDeleted ? 'italic text-gray-400' : 'text-gray-700'}`}>
+            <span className="mr-2 text-sm font-bold text-gray-800">{comment.author.nickname ?? '익명'}</span>
+            <span className={`text-sm leading-relaxed ${isDeleted ? 'italic text-gray-400' : 'text-gray-700'}`}>
               {comment.content}
             </span>
           </div>
         </div>
         {isOwner && !isDeleted && (
-          <button onClick={handleDelete} className="shrink-0 text-xs text-red-400 hover:text-red-600">
+          <button onClick={handleDelete} className="shrink-0 rounded-md px-2 py-1 text-xs text-gray-400 transition-colors duration-150 hover:bg-red-50 hover:text-red-400">
             삭제
           </button>
         )}
       </div>
-      <div className="mt-1">
+      <div className="mt-2 pl-43pxr">
         <span className="text-[11px] text-gray-400">{new Date(comment.createdAt).toLocaleString('ko-KR')}</span>
       </div>
       {error && <p className="mt-1 text-xs text-red-500">{error}</p>}

--- a/my-app/src/features/comments/CommentSection.tsx
+++ b/my-app/src/features/comments/CommentSection.tsx
@@ -48,13 +48,16 @@ export function CommentSection({ postId, currentUserId }: Props) {
   }
 
   return (
-    <section className="flex flex-col gap-4">
-      <h2 className="text-base font-semibold text-gray-800">댓글</h2>
+    <section className="flex flex-col gap-5">
+      <div className="flex items-center gap-8pxr">
+        <div className="h-4 w-1 rounded-full bg-[#00C471]" />
+        <h2 className="text-base font-bold text-gray-800">댓글</h2>
+      </div>
 
       {currentUserId ? (
         <CommentForm postId={postId} onSuccess={handleCommentAdded} />
       ) : (
-        <p className="text-sm text-gray-400">댓글을 작성하려면 로그인이 필요합니다.</p>
+        <p className="rounded-xl bg-gray-50 p-4 text-sm text-gray-400">댓글을 작성하려면 로그인이 필요합니다.</p>
       )}
 
       <div className="flex flex-col gap-3">
@@ -67,14 +70,19 @@ export function CommentSection({ postId, currentUserId }: Props) {
             onDeleted={handleDeleted}
           />
         ))}
-        {loading && <p className="text-sm text-gray-400">로딩 중...</p>}
+        {loading && (
+          <div className="flex items-center justify-center gap-2 py-4 text-sm text-gray-400">
+            <div className="h-3 w-3 animate-spin rounded-full border-2 border-green-400 border-t-transparent" />
+            <span>로딩 중...</span>
+          </div>
+        )}
         {!loading && comments.length === 0 && (
-          <p className="text-sm text-gray-400">첫 번째 댓글을 작성해보세요.</p>
+          <p className="rounded-xl bg-gray-50 py-8 text-center text-sm text-gray-400">첫 번째 댓글을 작성해보세요.</p>
         )}
         {hasNext && !loading && (
           <button
             onClick={() => loadComments(nextCursor)}
-            className="self-center text-sm text-green-500 hover:underline"
+            className="self-center rounded-full border border-green-200 bg-green-50 px-4 py-1.5 text-sm font-medium text-green-600 transition-all duration-150 hover:bg-green-100"
           >
             댓글 더 보기
           </button>

--- a/my-app/src/lib/post.ts
+++ b/my-app/src/lib/post.ts
@@ -11,6 +11,9 @@ export type PostSummary = {
   image3: string | null;
   createdAt: string;
   userId: string;
+  authorName: string;
+  authorNickname: string | null;
+  authorProfileImage: string | null;
   likeCount: number;
   commentCount: number;
   liked: boolean;

--- a/my-app/src/types/PostCard.types.ts
+++ b/my-app/src/types/PostCard.types.ts
@@ -6,4 +6,7 @@ export type PostCardProps = {
   commentCount: number;
   likeCount: number;
   liked?: boolean;
+  authorName: string;
+  authorNickname: string | null;
+  authorProfileImage: string | null;
 };


### PR DESCRIPTION
## #️⃣ Issue Number
- Closes #49 

## 📝 변경사항
게시글 목록/상세 페이지에서 작성자 정보(닉네임, 프로필 이미지)가 표시되지 않던 문제를 수정하고, 네비게이션 바의 싹심기 로고 클릭 시 홈으로 이동하도록 개선했습니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] 네비게이션 바의 싹심기 로고 클릭 시 `/home`으로 이동
- [x] 게시글 목록 API(`GET /api/posts`)에 user 테이블 조인 추가로 작성자 정보 반환
- [x] 게시글 상세 API의 `authorProfileImage` 매핑을 `user.image`로 통일
- [x] `PostSummary` 타입에 `authorName`, `authorNickname`, `authorProfileImage` 필드 추가
- [x] `PostCard` 컴포넌트에 작성자 프로필 이미지 및 닉네임 표시 (이미지 없을 시 이니셜 아바타 폴백)
- [x] 게시글 상세 페이지 작성자 영역에 프로필 이미지 표시 (이미지 없을 시 이니셜 아바타 폴백)

### 🔍 주안점 & 리뷰 포인트

- `GET /api/posts`에서 기존에는 `post` 테이블만 조회하고 있어 작성자 정보가 없었습니다. `user` 테이블을 `innerJoin`하여 해결했습니다.
- 프로필 이미지는 BetterAuth 기본 필드인 `user.image`를 사용합니다. (기존 상세 API에서 사용하던 `userProfileImageUrl` → `user.image`로 통일)

---

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경

## 🧪 영향 범위 및 테스트 (Impact & Tests)

### **영향을 받는 모듈/컴포넌트:**
`NavBar`, `PostCard`, `PostDetail 페이지`, `GET /api/posts`, `GET /api/posts/[postId]`, `PostSummary 타입`, `PostCardProps 타입`

### **테스트 방법:**
- [x] 수동 API 테스트 (Postman/Swagger)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [x] 관련 이슈를 연결했습니다.
